### PR TITLE
Clean up grindrails

### DIFF
--- a/Project/area/0 lost prologue/object/grindrail/Grindrail01.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 10)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail01" parent="." index="0" instance=ExtResource("2_uq7f1")]

--- a/Project/area/0 lost prologue/object/grindrail/Grindrail02.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 20)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail02" parent="." index="0" instance=ExtResource("2_drgck")]

--- a/Project/area/0 lost prologue/object/grindrail/Grindrail03.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 30)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail03" parent="." index="0" instance=ExtResource("2_fv2k4")]

--- a/Project/area/0 lost prologue/object/grindrail/Grindrail04.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 60)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail04" parent="." index="0" instance=ExtResource("2_s8d4h")]

--- a/Project/area/0 lost prologue/object/grindrail/Grindrail05.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 90)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail05" parent="." index="0" instance=ExtResource("2_cd6yw")]

--- a/Project/area/0 lost prologue/object/grindrail/Grindrail06.tscn
+++ b/Project/area/0 lost prologue/object/grindrail/Grindrail06.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 120)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ptuog")]
+[node name="Grindrail" instance=ExtResource("1_ptuog")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail06" parent="." index="0" instance=ExtResource("2_7j572")]

--- a/Project/area/1 sand oasis/act 3/map/RampageAct.tscn
+++ b/Project/area/1 sand oasis/act 3/map/RampageAct.tscn
@@ -7231,9 +7231,6 @@ transform = Transform3D(0.999829, -9.31323e-10, -0.0185169, -7.45058e-09, 1, 2.9
 
 [node name="InvisibleGrindrail1" parent="RingChainAct/Lap03/LowerHall" node_paths=PackedStringArray("rail", "railModel", "collider") instance=ExtResource("14_vbq4m")]
 transform = Transform3D(-0.999999, -1.43809e-16, 0.00240821, 1.10755e-16, 1, -1.11289e-16, -0.00240821, -4.82754e-17, -0.999999, 0.0137711, 2.13517, 42.609)
-rail = NodePath("../../../Lap02/LowerHall/InvisibleGrindrail1/Path3D")
-railModel = NodePath("../../../Lap02/LowerHall/InvisibleGrindrail1/Grindrail")
-collider = NodePath("../../../Lap02/LowerHall/InvisibleGrindrail1/CollisionShape3D")
 railLength = 60
 
 [node name="Rings1" type="Node3D" parent="RingChainAct/Lap03/LowerHall/InvisibleGrindrail1"]

--- a/Project/area/1 sand oasis/object/grindrail/Grindrail01.tscn
+++ b/Project/area/1 sand oasis/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_puas0")]
+[node name="Grindrail" instance=ExtResource("1_puas0")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail01" parent="." index="0" instance=ExtResource("1_vt1bk")]

--- a/Project/area/1 sand oasis/object/grindrail/Grindrail02.tscn
+++ b/Project/area/1 sand oasis/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_u2syb")]
+[node name="Grindrail" instance=ExtResource("1_u2syb")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail02" parent="." index="0" instance=ExtResource("1_q5gtv")]

--- a/Project/area/1 sand oasis/object/grindrail/Grindrail03.tscn
+++ b/Project/area/1 sand oasis/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_tim12")]
+[node name="Grindrail" instance=ExtResource("1_tim12")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail03" parent="." index="0" instance=ExtResource("2_hnw62")]

--- a/Project/area/1 sand oasis/object/grindrail/Grindrail04.tscn
+++ b/Project/area/1 sand oasis/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_k788x")]
+[node name="Grindrail" instance=ExtResource("1_k788x")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail04" parent="." index="0" instance=ExtResource("1_0ixhs")]

--- a/Project/area/1 sand oasis/object/grindrail/Grindrail05.tscn
+++ b/Project/area/1 sand oasis/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_jhok6")]
+[node name="Grindrail" instance=ExtResource("1_jhok6")]
 rail = NodePath("Path3D")
 startCapPath = NodePath("")
 endCapPath = NodePath("")

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail01.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_o46c5"]
 size = Vector3(2, 0.5, 10)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_f6aii")]
+[node name="Grindrail" instance=ExtResource("1_f6aii")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail01" parent="." index="0" instance=ExtResource("2_8u0m1")]

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail02.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_jsstc"]
 size = Vector3(2, 0.5, 20)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_ba1rx")]
+[node name="Grindrail" instance=ExtResource("1_ba1rx")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail02" parent="." index="0" instance=ExtResource("2_y4juk")]

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail03.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_n265x"]
 size = Vector3(2, 0.5, 30)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_g78b6")]
+[node name="Grindrail" instance=ExtResource("1_g78b6")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail03" parent="." index="0" instance=ExtResource("2_06vvj")]

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail04.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_tan5u"]
 size = Vector3(2, 0.5, 60)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_bhwkw")]
+[node name="Grindrail" instance=ExtResource("1_bhwkw")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail04" parent="." index="0" instance=ExtResource("2_ih3b5")]

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail05.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_muc2n"]
 size = Vector3(2, 0.5, 90)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_t4hor")]
+[node name="Grindrail" instance=ExtResource("1_t4hor")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail05" parent="." index="0" instance=ExtResource("2_pqj7y")]

--- a/Project/area/2 dino jungle/object/grindrail/Grindrail06.tscn
+++ b/Project/area/2 dino jungle/object/grindrail/Grindrail06.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_n265x"]
 size = Vector3(2, 0.5, 120)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_evfwc")]
+[node name="Grindrail" instance=ExtResource("1_evfwc")]
 rail = NodePath("Path3D")
 startCapPath = NodePath("")
 endCapPath = NodePath("")

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail01.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail02.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail03.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail04.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail05.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/3 evil foundry/object/grindrail/Grindrail06.tscn
+++ b/Project/area/3 evil foundry/object/grindrail/Grindrail06.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lqlhi")]
+[node name="Grindrail" instance=ExtResource("1_lqlhi")]
 rail = NodePath("Path3D")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="0"]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail01.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 10)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_p1w1g")]
+[node name="Grindrail" instance=ExtResource("1_p1w1g")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail01" parent="." index="0" instance=ExtResource("2_bi4al")]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail02.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 20)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_w28om")]
+[node name="Grindrail" instance=ExtResource("1_w28om")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail02" parent="." index="0" instance=ExtResource("2_ddqkh")]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail03.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 30)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_dlegt")]
+[node name="Grindrail" instance=ExtResource("1_dlegt")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail03" parent="." index="0" instance=ExtResource("2_fgoxa")]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail04.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 60)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_albqx")]
+[node name="Grindrail" instance=ExtResource("1_albqx")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail04" parent="." index="0" instance=ExtResource("2_rjnsf")]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail05.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 90)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_uvpae")]
+[node name="Grindrail" instance=ExtResource("1_uvpae")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail05" parent="." index="0" instance=ExtResource("2_mbpyd")]

--- a/Project/area/6 skeleton dome/object/grindrail/Grindrail06.tscn
+++ b/Project/area/6 skeleton dome/object/grindrail/Grindrail06.tscn
@@ -13,7 +13,7 @@ point_count = 2
 [sub_resource type="BoxShape3D" id="BoxShape3D_vt066"]
 size = Vector3(2, 0.5, 120)
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_f7xpy")]
+[node name="Grindrail" instance=ExtResource("1_f7xpy")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail06" parent="." index="0" instance=ExtResource("2_5tg63")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail01.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail01.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_0ayrh")]
+[node name="Grindrail" instance=ExtResource("1_0ayrh")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail01" parent="." index="0" instance=ExtResource("2_0i8it")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail02.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail02.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_nxgyf")]
+[node name="Grindrail" instance=ExtResource("1_nxgyf")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail02" parent="." index="0" instance=ExtResource("2_jra8i")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail03.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail03.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_4r7hh")]
+[node name="Grindrail" instance=ExtResource("1_4r7hh")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail03" parent="." index="0" instance=ExtResource("2_qdvwq")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail04.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail04.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_732qd")]
+[node name="Grindrail" instance=ExtResource("1_732qd")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail04" parent="." index="0" instance=ExtResource("2_yydij")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail05.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail05.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_0pop6")]
+[node name="Grindrail" instance=ExtResource("1_0pop6")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail05" parent="." index="0" instance=ExtResource("2_wx4kx")]

--- a/Project/area/7 night palace/object/grindrail/Grindrail06.tscn
+++ b/Project/area/7 night palace/object/grindrail/Grindrail06.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_8mlw4")]
+[node name="Grindrail" instance=ExtResource("1_8mlw4")]
 rail = NodePath("Path3D")
 
 [node name="Grindrail06" parent="." index="0" instance=ExtResource("2_ojnbr")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail01.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail01.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_clxrd")]
+[node name="Grindrail" instance=ExtResource("1_clxrd")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail01" parent="." index="0" instance=ExtResource("2_jkkae")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail02.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail02.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_wymt4")]
+[node name="Grindrail" instance=ExtResource("1_wymt4")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail02" parent="." index="0" instance=ExtResource("2_4iakr")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail03.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail03.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_lii0n")]
+[node name="Grindrail" instance=ExtResource("1_lii0n")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail03" parent="." index="0" instance=ExtResource("2_cucys")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail04.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail04.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_4axxn")]
+[node name="Grindrail" instance=ExtResource("1_4axxn")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail04" parent="." index="0" instance=ExtResource("2_8bftu")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail05.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail05.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_5p3r2")]
+[node name="Grindrail" instance=ExtResource("1_5p3r2")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail05" parent="." index="0" instance=ExtResource("2_tsthl")]

--- a/Project/area/7 night palace/object/grindrail/SpaceGrindrail06.tscn
+++ b/Project/area/7 night palace/object/grindrail/SpaceGrindrail06.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 point_count = 2
 
-[node name="Grindrail" node_paths=PackedStringArray("rail") instance=ExtResource("1_yq0hs")]
+[node name="Grindrail" instance=ExtResource("1_yq0hs")]
 rail = NodePath("Path3D")
 
 [node name="SpaceGrindrail06" parent="." index="0" instance=ExtResource("2_2q2yk")]

--- a/Project/object/stage/common/Grindrail.tscn
+++ b/Project/object/stage/common/Grindrail.tscn
@@ -7,8 +7,6 @@ collision_layer = 0
 collision_mask = 2
 monitorable = false
 script = ExtResource("1_k4svk")
-startCapPath = NodePath("")
-endCapPath = NodePath("")
 
 [connection signal="area_entered" from="." to="." method="OnEntered"]
 [connection signal="area_exited" from="." to="." method="OnExited"]

--- a/Project/object/stage/common/InvisibleGrindrail.tscn
+++ b/Project/object/stage/common/InvisibleGrindrail.tscn
@@ -11,13 +11,13 @@ material = ExtResource("3_caohd")
 size = Vector2(1, 1)
 orientation = 2
 
-[node name="InvisibleGrindrail" node_paths=PackedStringArray("rail", "railModel", "collider") instance=ExtResource("1_3avmn")]
+[node name="InvisibleGrindrail" instance=ExtResource("1_3avmn")]
 rail = NodePath("Path3D")
 isInvisibleRail = true
 railModel = NodePath("Grindrail")
 railMaterial = ExtResource("2_5lpto")
-startCapPath = NodePath("Start")
-endCapPath = NodePath("End")
+startCap = NodePath("Start")
+endCap = NodePath("End")
 collider = NodePath("CollisionShape3D")
 
 [node name="Grindrail" parent="." index="0" instance=ExtResource("2_8u20a")]


### PR DESCRIPTION
Removes direct references in favor of NodePaths to improve the level designing experience.