### PR TITLE
Add option to have camera blend between two settings based off player distance

### DIFF
--- a/Project/addons/stage_object_previewer/Plugin.cs
+++ b/Project/addons/stage_object_previewer/Plugin.cs
@@ -56,6 +56,8 @@ namespace Project.Editor.StageObjectPreviewer
 				UpdatePot();
 			else if (target is DriftTrigger)
 				UpdateDriftCorner();
+			else if (target is CameraTrigger)
+				DrawCameraBlend();
 			else if (target is MovingObject)
 				UpdateMovingObject();
 			else if (target is Majin)
@@ -92,6 +94,12 @@ namespace Project.Editor.StageObjectPreviewer
 			DriftTrigger trigger = target as DriftTrigger;
 			DrawLine(trigger.GlobalPosition, trigger.MiddlePosition, DefaultDrawColor);
 			DrawLine(trigger.MiddlePosition, trigger.EndPosition, SpecialDrawColor);
+		}
+
+		private void DrawCameraBlend()
+		{
+			CameraTrigger trigger = target as CameraTrigger;
+			DrawLine(trigger.GlobalPosition, trigger.BlendFinishPoint, DefaultDrawColor);
 		}
 
 		private void UpdateItemBox()

--- a/Project/object/trigger/modules/CameraTrigger.cs
+++ b/Project/object/trigger/modules/CameraTrigger.cs
@@ -92,7 +92,6 @@ public partial class CameraTrigger : StageTriggerModule
 	[Export]
 	private CameraSettingsResource previousSettings;
 	/// <summary> If blending two settings by distance, the second camera setting data that is used for the blend </summary>
-	
 	private CameraSettingsResource DistanceBlendSetting;
 	[Export]
 	private Camera3D referenceCamera;


### PR DESCRIPTION
Adds an additional checkbox to camera triggers to blend by distance. 
If enabled, when the trigger is activated the camera will switch/blend to the set camera settings as normal. But it will then continue to blend between the first setting and a second given setting based off players distance from a Vector3 point instead of time.

The point is set like Drift Triggers points, and is made viewable in the editor as well.

At least one camera angle in BK requires this, but I'd imagine this option could be usefull in parts of SR as well. 
(Looking at footage of Night Palace it seems to do this in the starting side view section)