### PR TITLE
Player Fixes

### DIFF
--- a/Project/object/player/resource/script/PlayerController.cs
+++ b/Project/object/player/resource/script/PlayerController.cs
@@ -258,7 +258,7 @@ public partial class PlayerController : CharacterBody3D
 	public new bool IsOnWall { get; set; }
 	public RaycastHit WallRaycastHit { get; set; }
 	/// <summary> Checks for walls forward and backwards (only in the direction the player is moving). </summary>
-	public void CheckWall(Vector3 castDirection = new())
+	public void CheckWall(Vector3 castDirection = new(), bool reduceSpeedDuringHeadonCollision = true)
 	{
 		IsOnWall = false;
 
@@ -276,7 +276,7 @@ public partial class PlayerController : CharacterBody3D
 		}
 
 		float wallDelta = ExtensionMethods.DeltaAngleRad(ExtensionMethods.CalculateForwardAngle(WallRaycastHit.normal.RemoveVertical(), IsOnGround ? PathFollower.Up() : Vector3.Up), MovementAngle);
-		if (wallDelta >= Mathf.Pi * .75f) // Process head-on collision
+		if (wallDelta >= Mathf.Pi * .8f) // Process head-on collision
 		{
 			// Cancel speed break
 			if (Skills.IsSpeedBreakActive)
@@ -291,10 +291,13 @@ public partial class PlayerController : CharacterBody3D
 				Skills.CallDeferred(PlayerSkillController.MethodName.ToggleSpeedBreak);
 			}
 
-			if (WallRaycastHit.distance <= CollisionSize.X + CollisionPadding)
-				MoveSpeed = 0; // Kill speed
-			else if (WallRaycastHit.distance <= CollisionSize.X + CollisionPadding + (MoveSpeed * PhysicsManager.physicsDelta))
-				MoveSpeed *= .9f; // Slow down drastically
+			if (reduceSpeedDuringHeadonCollision)
+			{
+				if (WallRaycastHit.distance <= CollisionSize.X + CollisionPadding)
+					MoveSpeed = 0; // Kill speed
+				else if (WallRaycastHit.distance <= CollisionSize.X + CollisionPadding + (MoveSpeed * PhysicsManager.physicsDelta))
+					MoveSpeed *= .9f; // Slow down drastically
+			}
 
 			IsOnWall = true;
 			return;

--- a/Project/object/player/resource/script/PlayerController.cs
+++ b/Project/object/player/resource/script/PlayerController.cs
@@ -299,7 +299,7 @@ public partial class PlayerController : CharacterBody3D
 			return;
 		}
 
-		if (IsMovingBackward || !IsOnGround)
+		if (Controller.IsStrafeModeActive || IsMovingBackward || !IsOnGround)
 			return;
 
 		// Reduce MoveSpeed when running against walls

--- a/Project/object/player/resource/script/PlayerController.cs
+++ b/Project/object/player/resource/script/PlayerController.cs
@@ -579,6 +579,7 @@ public partial class PlayerController : CharacterBody3D
 	[ExportGroup("States")]
 	[Export]
 	private CountdownState countdownState;
+	public bool IsCountdown { get; set; }
 	public void StartCountdown() => StateMachine.ChangeState(countdownState);
 
 	[Signal]

--- a/Project/object/player/resource/script/PlayerController.cs
+++ b/Project/object/player/resource/script/PlayerController.cs
@@ -48,6 +48,7 @@ public partial class PlayerController : CharacterBody3D
 		// Initialize state machine last to ensure components are ready		
 		StateMachine.Initialize(this);
 
+		ChangeHitbox("RESET");
 		ResetOrientation();
 		SnapToGround();
 		GetParent<CheckpointTrigger>().Activate(); // Save initial checkpoint

--- a/Project/object/player/resource/script/PlayerSkillController.cs
+++ b/Project/object/player/resource/script/PlayerSkillController.cs
@@ -18,6 +18,8 @@ public partial class PlayerSkillController : Node3D
 		MaxSoulPower = SaveManager.ActiveGameData.CalculateMaxSoulPower();
 
 		SetUpSkills();
+		timeBreakAnimator.Play("RESET");
+		speedBreakAnimator.Play("RESET");
 	}
 
 	#region Skills
@@ -382,8 +384,6 @@ public partial class PlayerSkillController : Node3D
 
 	public void ToggleSpeedBreak()
 	{
-		//Player.ResetActionState();
-
 		IsSpeedBreakActive = !IsSpeedBreakActive;
 		SoundManager.IsBreakChannelMuted = IsSpeedBreakActive;
 		breakTimer = IsSpeedBreakActive ? SpeedBreakDelay : BreakSkillsCooldown;

--- a/Project/object/player/resource/script/PlayerState.cs
+++ b/Project/object/player/resource/script/PlayerState.cs
@@ -180,4 +180,6 @@ public partial class PlayerState : Node
 		turningVelocity = 0;
 		Player.MovementAngle = targetMovementAngle;
 	}
+
+	protected virtual void ProcessGravity() => Player.VerticalSpeed = Mathf.MoveToward(Player.VerticalSpeed, Runtime.MaxGravity, Runtime.Gravity * PhysicsManager.physicsDelta);
 }

--- a/Project/object/player/resource/script/states/BackflipState.cs
+++ b/Project/object/player/resource/script/states/BackflipState.cs
@@ -54,6 +54,7 @@ public partial class BackflipState : PlayerState
 		ProcessGravity();
 		Player.ApplyMovement();
 		Player.CheckGround();
+		Player.CheckWall(Vector3.Zero, false);
 		Player.CheckCeiling();
 		Player.UpdateUpDirection(true, Player.PathFollower.HeightAxis);
 

--- a/Project/object/player/resource/script/states/BackflipState.cs
+++ b/Project/object/player/resource/script/states/BackflipState.cs
@@ -44,6 +44,7 @@ public partial class BackflipState : PlayerState
 	public override void ExitState()
 	{
 		Player.IsBackflipping = false;
+		Player.AttackState = PlayerController.AttackStates.None;
 	}
 
 	public override PlayerState ProcessPhysics()

--- a/Project/object/player/resource/script/states/BackstepState.cs
+++ b/Project/object/player/resource/script/states/BackstepState.cs
@@ -85,9 +85,15 @@ public partial class BackstepState : PlayerState
 		float targetMovementAngle = Player.Controller.GetTargetMovementAngle();
 		if (turnInstantly) // Turn instantly
 		{
-			turningVelocity = 0;
-			Player.MovementAngle = targetMovementAngle;
+			SnapRotation(targetMovementAngle);
 			return;
+		}
+
+		if (Player.Controller.IsHoldingDirection(targetMovementAngle, Player.MovementAngle + Mathf.Pi))
+		{
+			// Check for turning around
+			if (!Player.IsLockoutActive || Player.ActiveLockoutData.movementMode != LockoutResource.MovementModes.Strafe)
+				return;
 		}
 
 		// Use GroundSettings so backstep turning feels consistent with the run state

--- a/Project/object/player/resource/script/states/BackstepState.cs
+++ b/Project/object/player/resource/script/states/BackstepState.cs
@@ -79,22 +79,10 @@ public partial class BackstepState : PlayerState
 
 	protected override void ProcessTurning()
 	{
-		if (Mathf.IsZeroApprox(Player.MoveSpeed) && !Input.IsActionPressed("button_brake"))
+		float pathControlAmount = Player.Controller.CalculatePathControlAmount();
+		float targetMovementAngle = Player.Controller.GetTargetMovementAngle() + pathControlAmount;
+		if (DisableTurning(targetMovementAngle))
 			return;
-
-		float targetMovementAngle = Player.Controller.GetTargetMovementAngle();
-		if (turnInstantly) // Turn instantly
-		{
-			SnapRotation(targetMovementAngle);
-			return;
-		}
-
-		if (Player.Controller.IsHoldingDirection(targetMovementAngle, Player.MovementAngle + Mathf.Pi))
-		{
-			// Check for turning around
-			if (!Player.IsLockoutActive || Player.ActiveLockoutData.movementMode != LockoutResource.MovementModes.Strafe)
-				return;
-		}
 
 		// Use GroundSettings so backstep turning feels consistent with the run state
 		float speedRatio = Player.Stats.GroundSettings.GetSpeedRatioClamped(Player.MoveSpeed);

--- a/Project/object/player/resource/script/states/CountdownState.cs
+++ b/Project/object/player/resource/script/states/CountdownState.cs
@@ -14,6 +14,8 @@ public partial class CountdownState : PlayerState
 
 	public override void EnterState()
 	{
+		Player.IsCountdown = true;
+
 		Player.Transform = Transform3D.Identity;
 		Player.PathFollower.Resync();
 		Player.MovementAngle = Player.PathFollower.ForwardAngle;
@@ -24,6 +26,7 @@ public partial class CountdownState : PlayerState
 
 	public override void ExitState()
 	{
+		Player.IsCountdown = false;
 		Player.Animator.CancelOneshot();
 
 		// Snap camera to gameplay

--- a/Project/object/player/resource/script/states/FallState.cs
+++ b/Project/object/player/resource/script/states/FallState.cs
@@ -18,7 +18,7 @@ public partial class FallState : PlayerState
 	{
 		ProcessMoveSpeed();
 		ProcessTurning();
-		Player.VerticalSpeed = Mathf.MoveToward(Player.VerticalSpeed, Runtime.MaxGravity, Runtime.Gravity * PhysicsManager.physicsDelta);
+		ProcessGravity();
 		Player.ApplyMovement();
 		Player.IsMovingBackward = Player.Controller.IsHoldingDirection(Player.MovementAngle, Player.PathFollower.BackAngle);
 		Player.CheckGround();

--- a/Project/object/player/resource/script/states/GrindStepState.cs
+++ b/Project/object/player/resource/script/states/GrindStepState.cs
@@ -54,7 +54,7 @@ public partial class GrindStepState : PlayerState
 	public override PlayerState ProcessPhysics()
 	{
 		ProcessMoveSpeed();
-		Player.VerticalSpeed = Mathf.MoveToward(Player.VerticalSpeed, Runtime.MaxGravity, Runtime.Gravity * PhysicsManager.physicsDelta);
+		ProcessGravity();
 		ProcessTurning();
 		Player.ApplyMovement();
 		Player.CheckGround();

--- a/Project/object/player/resource/script/states/IdleState.cs
+++ b/Project/object/player/resource/script/states/IdleState.cs
@@ -24,6 +24,14 @@ public partial class IdleState : PlayerState
 
 	public override PlayerState ProcessPhysics()
 	{
+		if (Player.IsLockoutActive &&
+			Player.ActiveLockoutData.overrideSpeed &&
+			Mathf.IsZeroApprox(Player.ActiveLockoutData.speedRatio))
+		{
+			Player.Animator.IdleAnimation();
+			return null;
+		}
+
 		if (Player.Skills.IsSpeedBreakActive)
 			return runState;
 

--- a/Project/object/player/resource/script/states/JumpDashState.cs
+++ b/Project/object/player/resource/script/states/JumpDashState.cs
@@ -59,7 +59,7 @@ public partial class JumpDashState : PlayerState
 		Player.VerticalSpeed = Mathf.MoveToward(Player.VerticalSpeed, -jumpDashMaxGravity, jumpDashGravity * PhysicsManager.physicsDelta);
 		Player.ApplyMovement();
 		Player.CheckGround();
-		Player.CheckWall();
+		Player.CheckWall(Vector3.Zero, false);
 		Player.UpdateUpDirection(true);
 
 		if (Player.IsOnGround)
@@ -78,7 +78,6 @@ public partial class JumpDashState : PlayerState
 			}
 
 			// Kill speed when jump dashing into a wall to prevent splash jump from becoming obsolete
-			Player.MoveSpeed = 0;
 			Player.VerticalSpeed = Mathf.Clamp(Player.VerticalSpeed, -Mathf.Inf, 0);
 		}
 

--- a/Project/object/player/resource/script/states/JumpState.cs
+++ b/Project/object/player/resource/script/states/JumpState.cs
@@ -82,7 +82,7 @@ public partial class JumpState : PlayerState
 		Player.ApplyMovement();
 		Player.IsMovingBackward = Player.Controller.IsHoldingDirection(Player.MovementAngle, Player.PathFollower.BackAngle);
 		Player.CheckGround();
-		Player.CheckWall();
+		Player.CheckWall(Vector3.Zero, !isAccelerationJump);
 		Player.CheckCeiling();
 		Player.UpdateUpDirection();
 

--- a/Project/object/player/resource/script/states/JumpState.cs
+++ b/Project/object/player/resource/script/states/JumpState.cs
@@ -78,7 +78,7 @@ public partial class JumpState : PlayerState
 
 		ProcessMoveSpeed();
 		ProcessTurning();
-		UpdateVerticalSpeed();
+		ProcessGravity();
 		Player.ApplyMovement();
 		Player.IsMovingBackward = Player.Controller.IsHoldingDirection(Player.MovementAngle, Player.PathFollower.BackAngle);
 		Player.CheckGround();
@@ -129,7 +129,7 @@ public partial class JumpState : PlayerState
 			Player.MovementAngle = ExtensionMethods.ClampAngleRange(Player.MovementAngle, Player.PathFollower.ForwardAngle, MaxAccelerationJumpTurnAmount);
 	}
 
-	private void UpdateVerticalSpeed()
+	protected override void ProcessGravity()
 	{
 		if (isShortenedJump && Player.VerticalSpeed > 0)
 		{
@@ -143,7 +143,7 @@ public partial class JumpState : PlayerState
 				StartAccelerationJump();
 		}
 
-		Player.VerticalSpeed = Mathf.MoveToward(Player.VerticalSpeed, Runtime.MaxGravity, Runtime.Gravity * PhysicsManager.physicsDelta);
+		base.ProcessGravity();
 	}
 
 	private void StartAccelerationJump()

--- a/Project/object/trigger/state trigger/script/AutomationTrigger.cs
+++ b/Project/object/trigger/state trigger/script/AutomationTrigger.cs
@@ -35,6 +35,9 @@ public partial class AutomationTrigger : Area3D
 		if (Player.IsAutomationActive || !Player.IsOnGround)
 			return;
 
+		if (Player.IsCountdown)
+			return;
+
 		if (Player.IsTeleporting)
 			return;
 


### PR DESCRIPTION
Fixes the following control errors:
- Fixes break skills not resetting when restarting a level.
- Fixes fire backflip hitbox not resetting.
- Disables speed loss when running against the wall during an auto-run area.
- Fixes Countdown and Auto-Run regression from refactor.
- Fixes Ending control lock regression from refactor.
- Fixes turning around from a Backstep.
- Fixes turning during a Jump Dash.
- Allows player to Jump Dash/Accel Jump along walls.
- Makes backflip turning more consistent with the rest of the controls.
